### PR TITLE
Emit stats to statsd.

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,1 +1,0 @@
-package metrics

--- a/secret/secret_test.go
+++ b/secret/secret_test.go
@@ -18,7 +18,7 @@ func TestEncryptDecryptCycle(t *testing.T) {
 		t.Errorf("Got unexpected response from NewKey: %v", err)
 	}
 
-	s, err := NewWithKeyBytes(key)
+	s, err := New(&Config{KeyBytes: key})
 	if err != nil {
 		t.Errorf("Got unexpected response from NewWithKeyBytes: %v", err)
 	}
@@ -30,55 +30,6 @@ func TestEncryptDecryptCycle(t *testing.T) {
 	}
 
 	out, err := s.Open(sealed)
-	if err != nil {
-		t.Errorf("Got unexpected response from Open: %v", err)
-	}
-
-	// compare the messages
-	if subtle.ConstantTimeCompare(message, out) != 1 {
-		t.Errorf("Contents do not match: %v, %v", message, out)
-	}
-}
-
-func TestEncryptDecryptCycleWithKey(t *testing.T) {
-	randomProvider = &random.FakeRNG{}
-
-	// try and create new service with no key, should fail
-	s, err := New(&Config{})
-	if err == nil {
-		t.Errorf("Somehow got a Service, should not have gotten on (no key path given)")
-	}
-
-	// now get a service that has no key, by passing in a nil key
-	s, err = NewWithKeyBytes(nil)
-	if err != nil {
-		t.Errorf("Got unexpected response from NewWithKeyBytes: %v", err)
-	}
-
-	// try and seal, should fail because we didn't pass in a key
-	message := []byte("hello, box!")
-	sealed, err := s.Seal(message)
-	if err == nil {
-		t.Errorf("Got unexpected response from Seal: %v", err)
-	}
-
-	// should fail, again, no key
-	out, err := s.Open(sealed)
-	if err == nil {
-		t.Errorf("Got unexpected response from Open: %v", err)
-	}
-
-	// setup key to use, the spec zeros this array, so the key is all zeros (0x00, 0x00, 0x00, ...)
-	var secretKey [SecretKeyLength]byte
-
-	// should be able to seal because we passed in a key
-	sealed, err = s.SealWithKey(message, &secretKey)
-	if err != nil {
-		t.Errorf("Got unexpected response from Seal: %v", err)
-	}
-
-	// should be able to open now, passing in key
-	out, err = s.OpenWithKey(sealed, &secretKey)
 	if err != nil {
 		t.Errorf("Got unexpected response from Open: %v", err)
 	}


### PR DESCRIPTION
**Purpose**

A good way to look for malicious activity is successful and unsuccessful authentication/encryption events. Currently we have no way of doing this. This commit starts emitting these metrics to statsd. This way we can display it on a dashbaord and if we see a spike of unsuccessful authentication or encryption events we know someone may be trying to attack our system or something is going wrong on our end.

**Implementation**
- Before doing anything else, create a `metrics.Service` by calling `metrics.New` with the hostname and port of the statsd server. Optionally a prefix can be given to prefix all metrics. By deafult this is `lemma.{hostname}`.
- If you don't call `metrics.New` you can still call the `EmitSuccess` and `EmitFailure` methods, but nothing will happen (you still need to create a instance of `metrics.Service{}` to call those methods on). This is done to keep code clean, so instead of a `if` check every time you want to emit a metric, you can just try to emit the metric. It will be sent if you have the service configured. 
- Call `metrics.EmitSuccess` or `metrics.EmitFailure` whenever you wish to emit a metric. They are goroutine safe.
- Currently, the above two methods are called by `lemma.httpsign.auth.AuthenticateRequestWithKey` and `lemma.httpsign.secret.OpenWithKey`.

**Related Commits**
https://github.com/mailgun/pylemma/pull/3
