### PR TITLE
Increase timeouts.

### DIFF
--- a/httpsign/auth.go
+++ b/httpsign/auth.go
@@ -276,7 +276,7 @@ func (s *Service) checkTimestamp(timestampHeader string) (bool, error) {
 			now, s.config.TimestampHeaderName, timestamp, timestamp-now)
 	}
 
-	// if the timestamp is older than ttl + skew, it's invalid
+	// if the timestamp is older than ttl - skew, it's invalid
 	if timestamp <= now-int64(s.nonceCache.cacheTTL-MaxSkewSec) {
 		return false, fmt.Errorf("timestamp header too old; now: %v; %v: %v; difference: %v",
 			now, s.config.TimestampHeaderName, timestamp, now-timestamp)

--- a/httpsign/constants.go
+++ b/httpsign/constants.go
@@ -1,8 +1,8 @@
 package httpsign
 
-const MaxSkewSec = 20                     // 20 sec
-const CacheTimeout = 30                   // 30 sec
-const CacheCapacity = 5000 * CacheTimeout // 5,000 msg/sec * 30 sec = 150,000 elements
+const MaxSkewSec = 5                      // 5 sec
+const CacheTimeout = 100                  // 100 sec
+const CacheCapacity = 5000 * CacheTimeout // 5,000 msg/sec * 100 sec = 500,000 elements
 
 const XMailgunSignature = "X-Mailgun-Signature"
 const XMailgunSignatureVersion = "X-Mailgun-Signature-Version"


### PR DESCRIPTION
**Purpose**

Traffic on the internet can often take much longer than 10 seconds to transmit. This is especially so if large messages are being sent. This commit increases that timeout to 95 seconds so even large messages should fall within the acceptable window.

**Implementation**

Looking at the `checkTimestamp` function in `lemma.httpsign.auth`, imagine you are at some time `t`. The request can not be from more than `t + MaxSkewSec` in the future. The request can also not be from more than `t - (CacheTimeout - MaxSkewSec)` in the past. Therefore, if we want to allow a 95 second window, we have to increase `CacheTimeout` and/or decrease `MaxSkewSec`.

This was done by changing the constants, `CacheTimeout` is now `100 seconds` and `MaxSkewSec` is `5 seconds`.

**Related Commit**
https://github.com/mailgun/pylemma/pull/4
