### PR TITLE
Interfaces and ASCII serialization

### DIFF
--- a/secret/key.go
+++ b/secret/key.go
@@ -2,6 +2,8 @@ package secret
 
 import (
 	"encoding/base64"
+	"encoding/json"
+
 	"fmt"
 )
 
@@ -31,4 +33,30 @@ func EncodedStringToKey(encodedKey string) (*[SecretKeyLength]byte, error) {
 // KeyToEncodedString converts bytes into a base64-encoded string
 func KeyToEncodedString(keybytes *[SecretKeyLength]byte) string {
 	return base64.StdEncoding.EncodeToString(keybytes[:])
+}
+
+// Given SealedData returns equivalent URL safe base64 encoded string.
+func SealedDataToString(sealedData SealedData) (string, error) {
+	b, err := json.Marshal(sealedData)
+	if err != nil {
+		return "", err
+	}
+
+	return base64.URLEncoding.EncodeToString(b), nil
+}
+
+// Given a URL safe base64 encoded string, returns SealedData.
+func StringToSealedData(encodedBytes string) (SealedData, error) {
+	bytes, err := base64.URLEncoding.DecodeString(encodedBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	var sb SealedBytes
+	err = json.Unmarshal(bytes, &sb)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sb, nil
 }

--- a/secret/key_test.go
+++ b/secret/key_test.go
@@ -1,6 +1,7 @@
 package secret
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 
@@ -57,5 +58,37 @@ func TestKeyToHexString(t *testing.T) {
 	// check
 	if g, w := gotHexKey, "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="; g != w {
 		t.Errorf("Got: %v, Want: %v", g, w)
+	}
+}
+
+func TestSealedDataToString(t *testing.T) {
+	sb := &SealedBytes{
+		Ciphertext: []byte{0, 1, 2},
+		Nonce:      []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31},
+	}
+
+	gotSealedString, err := SealedDataToString(sb)
+	if err != nil {
+		t.Errorf("Unexpected response from SealedDataToString: %v", err)
+	}
+
+	if got, want := gotSealedString, "eyJDaXBoZXJ0ZXh0IjoiQUFFQyIsIk5vbmNlIjoiQUFFQ0F3UUZCZ2NJQ1FvTERBME9EeEFSRWhNVUZSWVhHQmthR3h3ZEhoOD0ifQ=="; got != want {
+		t.Errorf("Got sealed string: %v, Want: %v", got, want)
+	}
+}
+
+func TestStringToSealedData(t *testing.T) {
+	ss := "eyJDaXBoZXJ0ZXh0IjoiQUFFQyIsIk5vbmNlIjoiQUFFQ0F3UUZCZ2NJQ1FvTERBME9EeEFSRWhNVUZSWVhHQmthR3h3ZEhoOD0ifQ=="
+
+	gotSealedData, err := StringToSealedData(ss)
+	if err != nil {
+		t.Errorf("Unexpected response from StringToSealedData: %v", err)
+	}
+
+	if got, want := gotSealedData.CiphertextBytes(), []byte{0, 1, 2}; !bytes.Equal(got, want) {
+		t.Errorf("Got sealed bytes: %v, Want: %v", got, want)
+	}
+	if got, want := gotSealedData.NonceBytes(), []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}; !bytes.Equal(got, want) {
+		t.Errorf("Got sealed bytes: %v, Want: %v", got, want)
 	}
 }

--- a/tools/lemmacmd/lemmacmd.go
+++ b/tools/lemmacmd/lemmacmd.go
@@ -175,11 +175,11 @@ func generateKey(keypath string, salt []byte, keyiter int) (key *[secret.SecretK
 }
 
 // Encodes all data needed to decrypt message into a JSON string and writes it to disk.
-func writeCiphertext(salt []byte, keyiter int, isPass bool, sealed *secret.SealedBytes, filename string) error {
+func writeCiphertext(salt []byte, keyiter int, isPass bool, sealed secret.SealedData, filename string) error {
 	// fill in the ciphertext fields
 	ec := EncodedCiphertext{
-		CiphertextNonce: sealed.Nonce,
-		Ciphertext:      sealed.Ciphertext,
+		CiphertextNonce: sealed.NonceBytes(),
+		Ciphertext:      sealed.CiphertextBytes(),
 		CipherAlgorithm: "salsa20_poly1305",
 	}
 


### PR DESCRIPTION
**Purpose**

Expose interfaces for the secret package and service so that it is easier to develop tests for them when used. Also expose a way for encrypted data to easily be transformed into ASCII and in reverse.

**Implementation**

* Created `SecretService` interface that defines `Open` and `Seal`.
* Created `SealedData` interface that defined methods to obtain Ciphertext and Nonce in byte or hex encoded form.
* Created `SealedDataToString` and `StringToSealedData` to transform SealedBytes struct into a ASCII string and back.

**Related PR**
https://github.com/mailgun/lemma/pull/12
