### PR TITLE
Account for golang crypto relocation

### DIFF
--- a/secret/secret.go
+++ b/secret/secret.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"strings"
 
-	"code.google.com/p/go.crypto/nacl/secretbox"
+	"golang.org/x/crypto/nacl/secretbox"
 	"github.com/mailgun/lemma/random"
 	"github.com/mailgun/metrics"
 )


### PR DESCRIPTION
All repos from `code.google.com/p/` have been moved to `golang.org` 